### PR TITLE
Display symbol offsets in hexadecimal

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -885,7 +885,7 @@ void SetSymbolColumns( const KKP::KKPSymbol& symbol )
     ratio = 0;
 
   ImGui::TableSetColumnIndex( 1 );
-  ImGui::Text( "%d", symbol.sourcePos );
+  ImGui::Text( "0x%08x (%d)", symbol.sourcePos, symbol.sourcePos );
 
   ImGui::TableSetColumnIndex( 2 );
   ImGui::Text( "%d", symbol.cumulativeUnpackedSize );


### PR DESCRIPTION
I don't know if this is something you'd find useful, but while working on my own KKP-file-generating tooling, every other tool (`readelf`, linker output stats, ...) outputs everything in hexadecimal, so seeing only decimals here was a bit annoying. Feel free to accept or reject if you like.